### PR TITLE
Show issues from repositories on homepage

### DIFF
--- a/app/models/github/fetch_issues.rb
+++ b/app/models/github/fetch_issues.rb
@@ -12,7 +12,13 @@ module Github
     end
 
     def fetch!
-      parsed_body
+      parsed_body.map do |issue_hash|
+        Issue.new(
+          title: issue_hash[:title],
+          body: issue_hash[:body],
+          url: issue_hash[:url]
+        )
+      end
     end
 
     private

--- a/app/models/github/issue.rb
+++ b/app/models/github/issue.rb
@@ -1,0 +1,17 @@
+module Github
+  class Issue
+    def initialize(title:, body:, url:)
+      @title = title
+      @body = body
+      @url = url
+    end
+
+    attr_reader :title, :body, :url
+
+    def ==(other)
+      title == other.title &&
+        body == other.body &&
+        url == other.url
+    end
+  end
+end

--- a/app/models/github/repository.rb
+++ b/app/models/github/repository.rb
@@ -6,6 +6,10 @@ module Github
       @first_issue_label = first_issue_label
     end
 
-    attr_accessor :name, :language, :first_issue_label
+    def issues
+      @issues ||= FetchIssues.(repository: name, label: first_issue_label)
+    end
+
+    attr_reader :name, :language, :first_issue_label
   end
 end

--- a/app/views/home/index.html.slim
+++ b/app/views/home/index.html.slim
@@ -6,3 +6,9 @@ h1 First Issue
   ul
     - repositories.each do |repository|
       li = repository.name
+      h3 Issues
+      - repository.issues.each do |issue|
+        = link_to issue.url do
+          strong = issue.title
+          p = issue.body
+          br

--- a/spec/models/github/fetch_issues_spec.rb
+++ b/spec/models/github/fetch_issues_spec.rb
@@ -4,13 +4,22 @@ RSpec.describe Github::FetchIssues do
   describe '.call' do
     context 'when the call to Github succeeds' do
       it 'calls the Github issue endpoint and returns a parsed JSON' do
-        stubbed_response = [{ id: 1 }, { id: 2 }].to_json
+        stubbed_response = [
+          { title: 'My Issue 1', body: 'My body', url: 'http://google.com' },
+          { title: 'My Issue 2', body: 'Hello world', url: 'http://github.com' }
+        ].to_json
+
         stub_request(:get, 'https://api.github.com/repos/rails/rails/issues?labels=good-first-patch')
           .to_return(status: 200, body: stubbed_response)
 
         result = described_class.call(repository: 'rails/rails', label: 'good-first-patch')
 
-        expect(result).to eq([{ id: 1 }, { id: 2 }])
+        expect(result).to eq(
+          [
+            Github::Issue.new(title: 'My Issue 1', body: 'My body', url: 'http://google.com'),
+            Github::Issue.new(title: 'My Issue 2', body: 'Hello world', url: 'http://github.com')
+          ]
+        )
       end
     end
 


### PR DESCRIPTION
This makes the index page show the issues tagged with the "first issue" label for each project.
It makes issues a first class citizen by creating a dedicated class.